### PR TITLE
Fix awk multi-line content handling in ensure_block function

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -192,13 +192,24 @@ ensure_block() {
   local begin="### BEGIN ${marker}"
   local end="### END ${marker}"
   if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then
-    # Replace existing block
+    # Replace existing block using sed
     local tmp
     tmp="$(mktemp)"
-    awk -v b="$begin" -v e="$end" -v c="$content" '
-      $0 == b  { print b; print c; skip=1; next }
-      $0 == e  { skip=0; print e; next }
-      !skip    { print }
+    awk -v b="$begin" -v e="$end" '
+      BEGIN { skip=0; printed_content=0 }
+      $0 == b {
+        print b
+        printf "%s\n", ENVIRON["BLOCK_CONTENT"]
+        printed_content=1
+        skip=1
+        next
+      }
+      $0 == e {
+        skip=0
+        print e
+        next
+      }
+      !skip { print }
     ' "$file" > "$tmp" && mv "$tmp" "$file"
   elif [[ -f "$file" ]]; then
     # Append new block


### PR DESCRIPTION
## Summary
- Fixed the `ensure_block` function to properly handle multi-line content by using `ENVIRON["BLOCK_CONTENT"]` instead of passing content as an awk variable

## Changes
- Updated the awk script in `ensure_block` to read content from environment variable instead of `-v c="$content"`
- This avoids the "newline in string" error that occurred when processing multi-line content like the Zsh configuration block

## Testing
- This was made with qwen3.5-v1-122b-a10b-mlx-crack in 7m + 20m to open the PR