### PR TITLE
Fix ensure_block multi-line content handling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -192,14 +192,23 @@ ensure_block() {
   local begin="### BEGIN ${marker}"
   local end="### END ${marker}"
   if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then
-    # Replace existing block
+    # Replace existing block using line-by-line shell processing
     local tmp
     tmp="$(mktemp)"
-    awk -v b="$begin" -v e="$end" -v c="$content" '
-      $0 == b  { print b; print c; skip=1; next }
-      $0 == e  { skip=0; print e; next }
-      !skip    { print }
-    ' "$file" > "$tmp" && mv "$tmp" "$file"
+    local in_block=false
+    while IFS= read -r line || [[ -n "$line" ]]; do
+      if [[ "$line" == "$begin" ]]; then
+        in_block=true
+        echo "$begin" >> "$tmp"
+        printf '%s\n' "$content" >> "$tmp"
+      elif [[ "$line" == "$end" ]]; then
+        in_block=false
+        echo "$end" >> "$tmp"
+      elif ! $in_block; then
+        echo "$line" >> "$tmp"
+      fi
+    done < "$file"
+    mv "$tmp" "$file"
   elif [[ -f "$file" ]]; then
     # Append new block
     printf '\n%s\n%s\n%s\n' "$begin" "$content" "$end" >> "$file"


### PR DESCRIPTION
## Summary
Fixed the `ensure_block` function that was failing when processing multi-line content in .zshrc.

## Problem
The original awk implementation failed with "newline in string" errors when content contained literal newlines (like the zsh config block).

## Solution
Replaced awk with line-by-line shell processing using `read -r`. This properly handles multi-line content without any escaping issues.

Changes:
- Removed awk -v approach that couldn't handle embedded newlines
- Added while loop with read to process file line-by-line
- Tracks block state with boolean flag for clean replacement