### PR TITLE
Fix awk newline error in .zshrc setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -191,15 +191,24 @@ ensure_block() {
   local file="$1" marker="$2" content="$3"
   local begin="### BEGIN ${marker}"
   local end="### END ${marker}"
+
+  # Create a temp file for content to avoid shell/awk newline issues
+  local content_file
+  content_file="$(mktemp)"
+  printf '%s\n' "$content" > "$content_file"
+
   if [[ -f "$file" ]] && grep -qF "$begin" "$file" 2>/dev/null; then
     # Replace existing block
-    local tmp
-    tmp="$(mktemp)"
-    awk -v b="$begin" -v e="$end" -v c="$content" '
-      $0 == b  { print b; print c; skip=1; next }
+    local tmp="$(mktemp)"
+
+    awk -v b="$begin" -v e="$end" '
+      BEGIN { while ((getline line < cf) > 0) content = content (NR>1 ? "\n" : "") line; close(cf) }
+      $0 == b  { print b; print content; skip=1; next }
       $0 == e  { skip=0; print e; next }
       !skip    { print }
-    ' "$file" > "$tmp" && mv "$tmp" "$file"
+    ' cf="$content_file" "$file" > "$tmp" && mv "$tmp" "$file"
+
+    rm -f "$content_file"
   elif [[ -f "$file" ]]; then
     # Append new block
     printf '\n%s\n%s\n%s\n' "$begin" "$content" "$end" >> "$file"


### PR DESCRIPTION
This PR fixes the "awk: newline in string" errors when running the Zsh setup.

## Problem
The `ensure_block` function was passing multiline content via `-v c="$content"` to awk, which caused errors because shell newlines in variables broke awks command parsing.

## Solution
Write content to a temp file first, then use awks `getline` to read it in the BEGIN block.

---
Generated with qwen3.5-35b-a3b-mlx | Duration: 2m35s + 3m9s to make PR