### PR TITLE
Update Docker cask to docker-desktop

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -58,7 +58,7 @@ BREW_CORE=(
 
 CASK_DEVELOPMENT=(
   copilot-cli
-  docker
+  docker-desktop
   ghostty
   # insomnia         # DEPRECATED? — acquired by Kong, many users migrated to Bruno or Hoppscotch
   jetbrains-toolbox


### PR DESCRIPTION
Updates the Homebrew cask reference from the deprecated `docker` to `docker-desktop`, which is the current canonical name in Homebrew for Docker Desktop.

🤖 Generated with Claude Code