### PR TITLE
Add Highbeam setup and agent guidelines

### DIFF
--- a/.adrw-highbeam-aliases
+++ b/.adrw-highbeam-aliases
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# SOURCE https://github.com/adrw/.files
+# Highbeam-specific aliases
+
+# General
+# alias hb="..."
+
+# Git
+# alias gphm="git pull highbeam main"
+
+# CLI tools
+# alias hbctl="..."
+
+# VPN / networking
+# alias killvpn="..."

--- a/.adrw-highbeam-aliases
+++ b/.adrw-highbeam-aliases
@@ -3,14 +3,21 @@
 # SOURCE https://github.com/adrw/.files
 # Highbeam-specific aliases
 
-# General
-# alias hb="..."
+export HIGHBEAM_STAGING_POSTGRES_PORT=5433
+export HIGHBEAM_STAGING_POSTGRES_JDBC_URL=jdbc:postgresql://localhost:$HIGHBEAM_STAGING_POSTGRES_PORT/highbeam
+export HIGHBEAM_STAGING_POSTGRES_USERNAME=adrw@highbeam.co
 
-# Git
-# alias gphm="git pull highbeam main"
+export HIGHBEAM_PRODUCTION_POSTGRES_PORT=5434
+export HIGHBEAM_PRODUCTION_POSTGRES_JDBC_URL=jdbc:postgresql://localhost:$HIGHBEAM_PRODUCTION_POSTGRES_PORT/highbeam
+export HIGHBEAM_PRODUCTION_POSTGRES_USERNAME=adrw@highbeam.co
+export ISOLATED_DATA_VIEW_SQL_USERNAME=highbeam
 
-# CLI tools
-# alias hbctl="..."
+export HIGHBEAM_POSTGRES_JDBC_URL=$HIGHBEAM_STAGING_POSTGRES_JDBC_URL
+export HIGHBEAM_POSTGRES_USERNAME=$HIGHBEAM_STAGING_POSTGRES_USERNAME
 
-# VPN / networking
-# alias killvpn="..."
+export HIGHBEAM_SQL_INSTANCE_NAME=highbeam-production:us-central1:highbeam
+export HIGHBEAM_SQL_JDBC_URL=jdbc:postgresql://localhost:5434/highbeam
+export HIGHBEAM_SQL_USERNAME=adrw@highbeam.co
+
+alias highbeam_staging_db='PGPASSWORD=$(gcloud auth print-access-token) pgcli --host=localhost --port=$HIGHBEAM_STAGING_POSTGRES_PORT --username=$HIGHBEAM_STAGING_POSTGRES_USERNAME --dbname=highbeam'
+alias highbeam_production_db='PGPASSWORD=$(gcloud auth print-access-token) pgcli --host=localhost --port=$HIGHBEAM_PRODUCTION_POSTGRES_PORT --username=$HIGHBEAM_PRODUCTION_POSTGRES_USERNAME --dbname=highbeam'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+## v1/ directory — DO NOT MODIFY
+
+The `v1/` directory is legacy, read-only, and unmaintained. Do not suggest, make, or plan any code changes to files under `v1/`. Do not reference `v1/` code as a basis for new implementations. Treat it as archived.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/setup.sh
+++ b/setup.sh
@@ -132,6 +132,12 @@ CASK_BACKUP=(
   synology-surveillance-station-client
 )
 
+BREW_HIGHBEAM=(
+  # Add Highbeam-specific homebrew packages here, e.g.:
+  # awscli
+  # terraform
+)
+
 # ---------------------------------------------------------------------------
 # /etc/hosts blocklist URLs (Steven Black)
 # ---------------------------------------------------------------------------
@@ -772,7 +778,7 @@ PLUGINS
 
   # --- Shell aliases & functions ---
   section "Shell aliases & functions"
-  for dotfile in .adrw-aliases .adrw-functions; do
+  for dotfile in .adrw-aliases .adrw-functions .adrw-highbeam-aliases; do
     if [[ -f "${SCRIPT_DIR}/${dotfile}" ]]; then
       cp "${SCRIPT_DIR}/${dotfile}" "${HOME}/${dotfile}"
       info "Installed ~/${dotfile}"
@@ -830,6 +836,7 @@ alias lt="eza -la --git --sort=modified"
 # Custom aliases & functions
 [ -f "${HOME}/.adrw-functions" ] && source "${HOME}/.adrw-functions"
 [ -f "${HOME}/.adrw-aliases" ] && source "${HOME}/.adrw-aliases"
+[ -f "${HOME}/.adrw-highbeam-aliases" ] && source "${HOME}/.adrw-highbeam-aliases"
 
 # Starship prompt (loaded last)
 eval "$(starship init zsh)"
@@ -853,6 +860,25 @@ ZSHRC
   info "Zsh setup complete — restart your terminal or run 'source ~/.zshrc'"
 }
 
+run_highbeam() {
+  section "Highbeam setup"
+  install_homebrew
+
+  if [[ ${#BREW_HIGHBEAM[@]} -gt 0 ]]; then
+    brew_install_list "Highbeam packages" "${BREW_HIGHBEAM[@]}"
+  else
+    warn "BREW_HIGHBEAM array is empty — add packages to setup.sh"
+  fi
+
+  local dotfile=".adrw-highbeam-aliases"
+  if [[ -f "${SCRIPT_DIR}/${dotfile}" ]]; then
+    cp "${SCRIPT_DIR}/${dotfile}" "${HOME}/${dotfile}"
+    info "Installed ~/${dotfile}"
+  else
+    warn "${dotfile} not found in ${SCRIPT_DIR}"
+  fi
+}
+
 # ===========================================================================
 # Main menu
 # ===========================================================================
@@ -874,6 +900,7 @@ main() {
   echo "  5) Homecall blocking"
   echo "  6) Zsh setup (antidote, starship, fzf, zoxide, eza)"
   echo "  7) Hermit (cashapp/hermit — per-project toolchains)"
+  echo "  8) Highbeam setup (packages & aliases)"
   echo "  a) All of the above"
   echo "  q) Quit"
   echo ""
@@ -885,7 +912,7 @@ main() {
   fi
 
   if [[ "$choices" == *"a"* ]]; then
-    choices="1,2,3,4,5,6,7"
+    choices="1,2,3,4,5,6,7,8"
   fi
 
   IFS=',' read -ra selected <<< "$choices"
@@ -899,6 +926,7 @@ main() {
       5) run_homecall ;;
       6) run_zsh_setup ;;
       7) run_hermit ;;
+      8) run_highbeam ;;
       *) warn "Unknown selection: ${choice}" ;;
     esac
   done

--- a/setup.sh
+++ b/setup.sh
@@ -136,6 +136,10 @@ BREW_HIGHBEAM=(
   # Add Highbeam-specific homebrew packages here, e.g.:
   # awscli
   # terraform
+  google-cloud-sdk
+  hashicorp/tap/terraform
+  kubectl
+  pgcli
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Create `.adrw-highbeam-aliases` skeleton for Highbeam-specific aliases
- Add `BREW_HIGHBEAM` array and `run_highbeam()` function for company package installation
- Add menu option 8 for Highbeam setup in main menu
- Integrate Highbeam aliases into `.zshrc` sourcing
- Add `AGENTS.md` with instructions to keep `v1/` directory read-only and unmaintained

## Testing
Run `setup.sh` and select option 8 (Highbeam setup). Fill in `.adrw-highbeam-aliases` with your company-specific aliases and add packages to the `BREW_HIGHBEAM` array before using.

🤖 Generated with [Claude Code](https://claude.com/claude-code)