### PR TITLE
Fix Highbeam aliases not sourced in .zshrc

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -881,6 +881,13 @@ run_highbeam() {
   else
     warn "${dotfile} not found in ${SCRIPT_DIR}"
   fi
+
+  # Ensure .zshrc sources the aliases file even if run_zsh_setup was not run
+  local zshrc="${HOME}/.zshrc"
+  local highbeam_block='# Highbeam aliases
+[ -f "${HOME}/.adrw-highbeam-aliases" ] && source "${HOME}/.adrw-highbeam-aliases"'
+  ensure_block "$zshrc" "highbeam" "$highbeam_block"
+  info ".zshrc Highbeam block updated (### BEGIN/END highbeam)"
 }
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- `run_highbeam()` copied `.adrw-highbeam-aliases` to `~/` but never added a sourcing line to `.zshrc`
- The source line only existed in the `adrw-dotfiles` block written by `run_zsh_setup()` (option 6)
- Now `run_highbeam()` uses `ensure_block` to independently ensure `.zshrc` sources the file

## Test plan
- [ ] Run `./setup.sh` and select option 8 (Highbeam setup)
- [ ] Verify `~/.zshrc` contains `### BEGIN highbeam` / `### END highbeam` block
- [ ] Run `source ~/.zshrc` and confirm Highbeam aliases are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)